### PR TITLE
Unpack into make_map instead of using to_map

### DIFF
--- a/argo/argo.hpp
+++ b/argo/argo.hpp
@@ -127,8 +127,10 @@ inline auto const collect = [](auto named_type_argptr_pairs,
                                auto named_type_kwargptr_pairs) constexpr {
   using boost::hana::concat;
   using boost::hana::to_map;
+  using boost::hana::unpack;
+  using boost::hana::make_map;
 
-  return to_map(concat(named_type_argptr_pairs, named_type_kwargptr_pairs));
+  return unpack(concat(named_type_argptr_pairs, named_type_kwargptr_pairs), make_map);
 };
 
 inline auto const invoke_swizzled = [](auto   arg_order,


### PR DESCRIPTION
This fixes the code generation issues. The problem is that `to_map` allows for duplicate keys in the "from" sequence, which means it needs to recursively insert into a `hana::map`. This is both very bad for codegen and for compile-times. `make_map`, on the other hand, requires all the keys to be distinct, which makes it much more straightforward and much easier to optimize.

With this, I get the following codegen for `test_calls.cpp` on Clang:

```asm
	.section	__TEXT,__text,regular,pure_instructions
	.macosx_version_min 10, 11
	.globl	__Z10call_kwfoov
	.p2align	4, 0x90
__Z10call_kwfoov:                       ## @_Z10call_kwfoov
	.cfi_startproc
## BB#0:
	pushq	%rbp
Lcfi0:
	.cfi_def_cfa_offset 16
Lcfi1:
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
Lcfi2:
	.cfi_def_cfa_register %rbp
	movl	$2, %edi
	movl	$4, %esi
	movl	$3, %edx
	popq	%rbp
	jmp	__Z3fooiii              ## TAILCALL
	.cfi_endproc

	.globl	__Z11call_kwfoo2v
	.p2align	4, 0x90
__Z11call_kwfoo2v:                      ## @_Z11call_kwfoo2v
	.cfi_startproc
## BB#0:
	pushq	%rbp
Lcfi3:
	.cfi_def_cfa_offset 16
Lcfi4:
	.cfi_offset %rbp, -16
	movq	%rsp, %rbp
Lcfi5:
	.cfi_def_cfa_register %rbp
	movl	$2, %edi
	movl	$4, %esi
	movl	$3, %edx
	popq	%rbp
	jmp	__Z3fooiii              ## TAILCALL
	.cfi_endproc


.subsections_via_symbols
```

Fixes #1 